### PR TITLE
auto-create major tag on new release

### DIFF
--- a/.github/workflows/on-release.yaml
+++ b/.github/workflows/on-release.yaml
@@ -1,0 +1,12 @@
+name: Tag major release
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: cloudposse/github-action-major-release-tagger@v1


### PR DESCRIPTION
Will auto-create and update a major tag (`v1` or such) based on newly published release.

See also recommendation in github docs https://docs.github.com/en/actions/creating-actions/releasing-and-maintaining-actions#example-developer-process