### PR TITLE
skip known bad repos

### DIFF
--- a/action.py
+++ b/action.py
@@ -30,6 +30,12 @@ from urllib.request import urlopen
 from urllib.error import HTTPError
 from urllib.parse import urljoin
 
+# known bad repositories that we'll just have to skip for now
+BAD_REPOS = [
+    'https://packages.monokai.pro/packages.json',
+    'https://raw.githubusercontent.com/blake-regalia/linked-data.syntaxes/master/channels/sublime/package-control.json'
+]
+
 generator_method_type = 'method'
 
 parser = argparse.ArgumentParser()
@@ -643,6 +649,10 @@ class TestContainer(object):
                 return
 
             success = True
+
+            if path in BAD_REPOS:
+                stream.write("skipping (known bad repo)")
+                return
 
             # Do not generate 1000 failing tests for not yet updated repos
             if schema != '3.0.0':


### PR DESCRIPTION
There are 2 repositories that don't pass our test (ignoring all those on 2.0 or even older schemas). I have reached out out to them to fix it ([1](https://github.com/blake-regalia/linked-data.syntaxes/pull/32), [2](https://github.com/monokai-pro/sublime-text/issues/191)), maybe that will eventually happen (it does [sometimes happen](https://github.com/JesseTG/ribosome-sublime/pull/1)). Meanwhile though, I want to be able to run these tests and ensure no regressions happen. 

This PR adds a blacklist of the 2 failing repositories so the tests pass while those are awaiting resolvement. 